### PR TITLE
Introduce `data` field as the main property on which to get/set other properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ const fileUrl = 'https://concepts.datalad.org/s/things/v1.shacl.ttl';
 // Listen for and act on the 'graphLoaded' event
 shapesDS.addEventListener('graphLoaded', (event) => {
     console.log('Shapes graph fully loaded:', event.detail)
-    console.log(shapesDS.propertyGroups)
-    console.log(shapesDS.nodeShapes)
-    console.log(shapesDS.nodeShapeNames)
-    console.log(shapesDS.nodeShapeNamesArray)
-    console.log(shapesDS.nodeShapeIRIs)
-    console.log(shapesDS.prefixes)
-    console.log(shapesDS.serializedGraph)
-    console.log(shapesDS.graphLoaded)
-    console.log(shapesDS.prefixesLoaded)
-    console.log(shapesDS.graph)
-    console.log(shapesDS.graph.size)
+    console.log(shapesDS.data.propertyGroups)
+    console.log(shapesDS.data.nodeShapes)
+    console.log(shapesDS.data.nodeShapeNames)
+    console.log(shapesDS.data.nodeShapeNamesArray)
+    console.log(shapesDS.data.nodeShapeIRIs)
+    console.log(shapesDS.data.prefixes)
+    console.log(shapesDS.data.serializedGraph)
+    console.log(shapesDS.data.graphLoaded)
+    console.log(shapesDS.data.prefixesLoaded)
+    console.log(shapesDS.data.graph)
+    console.log(shapesDS.data.graph.size)
 });
 // Load the RDF
 shapesDS.loadRDF(fileUrl);

--- a/src/classes/ClassDataset.js
+++ b/src/classes/ClassDataset.js
@@ -7,8 +7,8 @@ import { RDFS } from '../modules/namespaces';
 
 export class ClassDataset extends RdfDataset {
     
-    constructor() {
-        super()
+    constructor(data = {}) {
+        super(data)
     }
 
     onDataFn(quad) {

--- a/src/classes/FormBase.js
+++ b/src/classes/FormBase.js
@@ -8,7 +8,7 @@ import { isEmptyObject, toIRI} from '../modules/utils';
 
 export class FormBase {
 
-    constructor(id_iri = null) {
+    constructor(id_iri = null, content = {}) {
 
         if (!id_iri) {
             var msg = "id_iri is a required argument"
@@ -16,7 +16,7 @@ export class FormBase {
             throw new Error(msg)
         }
         this.ID_IRI = id_iri
-		this.content = {}
+		this.content = content
         this.ignoredProperties = [
             RDF.type.value,
         ]
@@ -230,7 +230,7 @@ export class FormBase {
         var quadArray = RdfDS.getSubjectTriples(subject_term)
         var IdQuadExists = false
         quadArray.forEach((quad) => {
-            var predicate_uri = toIRI(quad.predicate.value, RdfDS.prefixes)
+            var predicate_uri = toIRI(quad.predicate.value, RdfDS.data.prefixes)
             if (predicate_uri === this.ID_IRI) {
                 IdQuadExists = true
             }
@@ -253,7 +253,7 @@ export class FormBase {
         if (this.content[class_uri]) {
             // If we are in edit mode, the first step is to delete existing quads from graphData
             if (editMode) {
-                RdfDS.graph.deleteMatches(rdf.namedNode(node_uri), null, null, null)
+                RdfDS.data.graph.deleteMatches(rdf.namedNode(node_uri), null, null, null)
             }
 
             // Then we generate the quads
@@ -261,7 +261,7 @@ export class FormBase {
             var quads = this.formNodeToQuads(class_uri, node_uri, shapesDS)
             // and add them to the dataset
             quads.forEach(quad => {
-                RdfDS.graph.add(quad)
+                RdfDS.addQuad(quad)
             });
 
             // Some next steps depend on the type of the record's subject
@@ -283,8 +283,8 @@ export class FormBase {
                 var objectQuads = RdfDS.getObjectTriples(rdf.namedNode(node_uri))
                 objectQuads.forEach((quad) => {
                     let new_quad = rdf.quad(quad.subject, quad.predicate, subject)
-                    RdfDS.graph.delete(quad)
-                    RdfDS.graph.add(new_quad)
+                    RdfDS.data.graph.delete(quad)
+                    RdfDS.data.graph.add(new_quad)
                 });
             }
             // Change formdata node_uri to the actual id, if this was present:

--- a/tests/ClassDataset.test.js
+++ b/tests/ClassDataset.test.js
@@ -18,8 +18,8 @@ describe('ClassDataset', () => {
 
         console.log("Running ClassDataset Test 1...")
 
-        expect(dataset.graphLoaded).toBe(false);
-        expect(dataset.prefixesLoaded).toBe(false);
+        expect(dataset.data.graphLoaded).toBe(false);
+        expect(dataset.data.prefixesLoaded).toBe(false);
 
         server = httpServer.createServer({ });
         server.listen(PORT, HOST, (err) => {
@@ -29,9 +29,9 @@ describe('ClassDataset', () => {
         const fileUrl = `http://${HOST}:${PORT}/tests/mockData.ttl`
         dataset.loadRDF(fileUrl);
         await new Promise(resolve => dataset.addEventListener('graphLoaded', resolve));
-        expect(dataset.graph.size).toBe(1);
-        expect(dataset.graphLoaded).toBe(true);
-        expect(dataset.prefixesLoaded).toBe(true);
+        expect(dataset.data.graph.size).toBe(1);
+        expect(dataset.data.graphLoaded).toBe(true);
+        expect(dataset.data.prefixesLoaded).toBe(true);
         const serializedGraph = await dataset.serializeGraph();
         expect(serializedGraph).not.toContain('<http://example.com/subject>');
         expect(serializedGraph).not.toContain('<http://example.com/predicate>');

--- a/tests/FormBase.test.js
+++ b/tests/FormBase.test.js
@@ -93,7 +93,7 @@ describe('FormBase', () => {
         form.saveNode(class_uri, subject_uri, shapesDS, rdfDSnew, false)
         // Even though formdata has 3 predicates for the record,
         // the id_iri field should not be saved as a separate quad
-        expect(rdfDSnew.graph.size).toBe(2)
+        expect(rdfDSnew.data.graph.size).toBe(2)
     });
 
 

--- a/tests/RdfDataset.test.js
+++ b/tests/RdfDataset.test.js
@@ -20,7 +20,7 @@ describe('RdfDataset', () => {
     // test creation of class instance
     it('should create an empty dataset', () => {
         console.log(`Running RdfDataset Test ${i++}...`)
-        expect(dataset.graph.size).toBe(0);
+        expect(dataset.data.graph.size).toBe(0);
     });
 
     it('should add a quad to the dataset', () => {
@@ -32,8 +32,8 @@ describe('RdfDataset', () => {
 
         dataset.addQuad(quad);
 
-        expect(dataset.graph.size).toBe(1);
-        expect(dataset.graph.has(quad)).toBe(true);
+        expect(dataset.data.graph.size).toBe(1);
+        expect(dataset.data.graph.has(quad)).toBe(true);
     });
 
     it('should correctly detect an RDF list', () => {
@@ -88,18 +88,18 @@ describe('RdfDataset', () => {
             if (err && err.code !== 'EADDRINUSE') throw err;
             console.log(`Test server started on http://${HOST}:${PORT}`);
         });
-        expect(dataset.graphLoaded).toBe(false);
-        expect(dataset.prefixesLoaded).toBe(false);
+        expect(dataset.data.graphLoaded).toBe(false);
+        expect(dataset.data.prefixesLoaded).toBe(false);
         const fileUrl = `http://${HOST}:${PORT}/tests/mockData.ttl`
         const graphLoadedHandler = vi.fn();
         dataset.addEventListener('graphLoaded', graphLoadedHandler);
         dataset.loadRDF(fileUrl);
         await new Promise(resolve => dataset.addEventListener('graphLoaded', resolve));
         expect(graphLoadedHandler).toHaveBeenCalledTimes(1);
-        expect(dataset.graph.size).toBe(2);
-        expect(dataset.prefixes['ex']).toBe('http://example.com/');
-        expect(dataset.graphLoaded).toBe(true);
-        expect(dataset.prefixesLoaded).toBe(true);
+        expect(dataset.data.graph.size).toBe(2);
+        expect(dataset.data.prefixes['ex']).toBe('http://example.com/');
+        expect(dataset.data.graphLoaded).toBe(true);
+        expect(dataset.data.prefixesLoaded).toBe(true);
 
         console.log(`Closing server on http://${HOST}:${PORT}`);
         server.close();
@@ -112,7 +112,7 @@ describe('RdfDataset', () => {
         dataset.addEventListener('prefix', prefixHandler);
         dataset.onPrefixFn('ex', rdf.namedNode('http://example.com/'));
         expect(prefixHandler).toHaveBeenCalledTimes(1);
-        expect(dataset.prefixes['ex']).toBe('http://example.com/');
+        expect(dataset.data.prefixes['ex']).toBe('http://example.com/');
     });
 
     it('should resolve blank nodes correctly', () => {

--- a/tests/ShapesDataset.test.js
+++ b/tests/ShapesDataset.test.js
@@ -15,8 +15,8 @@ describe('ShapesDataset', () => {
     });
 
     it('should load RDF data from Turtle file and populate all shapes-related variables', async () => {
-        expect(dataset.graphLoaded).toBe(false);
-        expect(dataset.prefixesLoaded).toBe(false);
+        expect(dataset.data.graphLoaded).toBe(false);
+        expect(dataset.data.prefixesLoaded).toBe(false);
         server = httpServer.createServer({ });
         server.listen(PORT, HOST, (err) => {
             if (err && err.code !== 'EADDRINUSE') throw err;
@@ -25,26 +25,26 @@ describe('ShapesDataset', () => {
         const fileUrl = `http://${HOST}:${PORT}/tests/mockShapes.ttl`
         dataset.loadRDF(fileUrl);
         await new Promise(resolve => dataset.addEventListener('graphLoaded', resolve));
-        expect(dataset.graphLoaded).toBe(true);
-        expect(dataset.prefixesLoaded).toBe(true);
-        expect(dataset.graph.size).toBe(318); // number of quads in the mockShapes.ttl file
+        expect(dataset.data.graphLoaded).toBe(true);
+        expect(dataset.data.prefixesLoaded).toBe(true);
+        expect(dataset.data.graph.size).toBe(318); // number of quads in the mockShapes.ttl file
         // Test content of all loaded variables
-        expect(dataset.nodeShapeNames).toEqual(
+        expect(dataset.data.nodeShapeNames).toEqual(
             {
                 AttributeSpecification: 'https://concepts.datalad.org/s/things/v1/AttributeSpecification',
                 Person: 'https://concepts.datalad.org/s/social/unreleased/Person',
                 DOI: 'https://concepts.datalad.org/s/identifiers/unreleased/DOI'
             }
         )
-        expect(dataset.nodeShapeNamesArray).toEqual(['AttributeSpecification', 'DOI', 'Person'])
-        expect(dataset.nodeShapeIRIs).toEqual(
+        expect(dataset.data.nodeShapeNamesArray).toEqual(['AttributeSpecification', 'DOI', 'Person'])
+        expect(dataset.data.nodeShapeIRIs).toEqual(
             [
                 'https://concepts.datalad.org/s/identifiers/unreleased/DOI',
                 'https://concepts.datalad.org/s/social/unreleased/Person',
                 'https://concepts.datalad.org/s/things/v1/AttributeSpecification'
             ]
         )
-        expect(dataset.propertyGroups).toEqual(
+        expect(dataset.data.propertyGroups).toEqual(
             {
                 'https://concepts.datalad.org/s/things/v1/BasicPropertyGroup': {
                   'http://www.w3.org/ns/shacl#order': '0',
@@ -58,7 +58,7 @@ describe('ShapesDataset', () => {
                 }
             }
         )
-        expect(dataset.prefixes).toEqual(
+        expect(dataset.data.prefixes).toEqual(
             {
                 'ex': 'http://example.com/',
                 'dlidentifiers': 'https://concepts.datalad.org/s/identifiers/unreleased/',


### PR DESCRIPTION
This is in response to the process of trying to turn class instances into reactive objects. Since this library is a core dependency of `shacl-vue` which uses Vuejs, and since this library is independent of Vuejs, an external package should be able to take `shacl-tulip`'s exports and make them reactive. It has been a challenging process to figure out how to do this generally. Refer to https://github.com/psychoinformatics-de/shacl-vue/issues/84.

So the current best solution that I could find is to introduce a `data` argument, which defaults to an empty object, to the `RdfDataset` class and to set this as the value of `this.data` in the class constructor. This allows external libraries to pass a `reactive` object (e.g. `reactive({})`; importantly NOT a `ref()`) to the constructor, and afterward the reactive object will be accessible on the `data` property of the class instance. All data-related properties get moved to be properties of the `data` property and methods remain where they are. Additionally, tests were updated to reflect this change.