### PR TITLE
Fix objectKeysToNull is not defined issue, and update tests

### DIFF
--- a/src/classes/FormBase.js
+++ b/src/classes/FormBase.js
@@ -84,11 +84,11 @@ export class FormBase {
         }
         // clear node instance at provided index
         else {
-            objectKeysToNull(this.content[class_uri][subject_uri], setVal)
+            this._objectKeysToNull(this.content[class_uri][subject_uri], setVal)
         }
     }
 
-    static objectKeysToNull(obj, setVal = [null]) {
+    _objectKeysToNull(obj, setVal = [null]) {
         for (var key in obj) {
             if (obj.hasOwnProperty(key)) {
                 obj[key] = setVal;

--- a/tests/FormBase.test.js
+++ b/tests/FormBase.test.js
@@ -99,6 +99,36 @@ describe('FormBase', () => {
     });
 
 
+    it('should handle functionality for clearing/removing correctly', async () => {
+        let class_uri = 'https://concepts.datalad.org/s/social/unreleased/Person'
+        let subject_uri = 'http://example.com/testPerson'
+        let subject2_uri = 'http://example.com/testPerson2'
+        let predicate_uri = 'https://concepts.datalad.org/s/social/unreleased/given_name'
+        // Test add a subject and objects
+        form.addSubject(class_uri, subject_uri)
+        form.addPredicate(class_uri, subject_uri, predicate_uri)
+        form.content[class_uri][subject_uri][predicate_uri][0] = "TestName"
+        form.addObject(class_uri, subject_uri, predicate_uri)
+        // Test clearing the subject
+        form.clearSubject(class_uri, subject_uri)
+        expect(form.content[class_uri][subject_uri][predicate_uri]).toEqual([null])
+        // Test removing the subject
+        // First add one more subject, then remove it, then remove the original subject
+        form.addSubject(class_uri, subject2_uri)
+        expect(Object.keys(form.content[class_uri])).toContain(subject_uri)
+        expect(Object.keys(form.content[class_uri])).toContain(subject2_uri)
+        form.removeSubject(class_uri, subject2_uri)
+        expect(Object.keys(form.content[class_uri])).not.toContainEqual(subject2_uri)
+        // now remove original subject, after which the whole node should also be removed
+        form.removeSubject(class_uri, subject_uri)
+        expect(Object.keys(form.content)).not.toContainEqual(class_uri)
+    })
+
+
+
+    
+
+
 
 
 


### PR DESCRIPTION
This issue was not picked up in testing, so extra tests were added to test the 'clearSubject' function, which calls objectKeysToNull. A test for removeSubject was also missing, and added here.

closes https://github.com/psychoinformatics-de/shacl-tulip/issues/9